### PR TITLE
Added new Desert filter button and updated desert campsite types.

### DIFF
--- a/campsitesData.js
+++ b/campsitesData.js
@@ -672,8 +672,8 @@ const campsitesData = [
             "Photography",
             "Hot springs"
         ],
-        "type": "mountain",
-        "tags": ["mountain", "desert", "hiking", "texas"]
+        "type": "desert",
+        "tags": ["desert", "hiking", "texas"]
     },
     {
         "id": 25,
@@ -896,8 +896,8 @@ const campsitesData = [
             "Bird watching",
             "Sunset viewing"
         ],
-        "type": "forest",
-        "tags": ["forest", "desert", "hiking", "arizona"]
+        "type": "desert",
+        "tags": ["desert", "hiking", "arizona"]
     },
     {
         "id": 33,
@@ -924,8 +924,8 @@ const campsitesData = [
             "Stargazing",
             "Bat watching"
         ],
-        "type": "mountain",
-        "tags": ["mountain", "desert", "caves", "newmexico"]
+        "type": "desert",
+        "tags": ["desert", "caves", "newmexico"]
     },
     {
         "id": 34,

--- a/index.html
+++ b/index.html
@@ -86,6 +86,10 @@
                             <i class="fas fa-umbrella-beach"></i>
                             Beach
                         </button>
+                        <button class="filter-btn" data-filter="desert">
+                            <i class="fas fa-sun"></i>
+                            Desert
+                        </button>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
This PR introduces a dedicated "Desert" filter to improve campsite categorization and filtering accuracy.

**Changes**
Added a Desert filter button to the navigation filter bar
Reclassified the following campsites from incorrect categories to Desert:

- Big Bend National Park Campground.
- Arizona Desert Campground.
- New Mexico High Desert Campground.

**Problem**

Desert campsites were incorrectly appearing under the Forest filter, which created confusion for users specifically searching for forest environments.

**Solution**

Implemented a Desert filter and updated relevant campsite classifications to ensure campsites are displayed under the correct category.

**Testing**

1. Open the app
2. Select the Desert filter
3. Verify that:

- Only desert-designated campsites are shown.
- Previously miscategorized campsites no longer appear under the Forest filter.
- Make sure the Desert button highlights/activates the same way the other buttons do when clicked.

**Notes**

This change improves filtering accuracy and provides a clearer browsing experience for users searching by environment type.