### PR TITLE
Add Desert filter and fix mislabeled desert campsites

### DIFF
--- a/campsitesData.js
+++ b/campsitesData.js
@@ -672,7 +672,7 @@ const campsitesData = [
             "Photography",
             "Hot springs"
         ],
-        "type": "mountain",
+        "type": "desert",
         "tags": ["mountain", "desert", "hiking", "texas"]
     },
     {
@@ -896,7 +896,7 @@ const campsitesData = [
             "Bird watching",
             "Sunset viewing"
         ],
-        "type": "forest",
+        "type": "desert",
         "tags": ["forest", "desert", "hiking", "arizona"]
     },
     {
@@ -924,7 +924,7 @@ const campsitesData = [
             "Stargazing",
             "Bat watching"
         ],
-        "type": "mountain",
+        "type": "desert",
         "tags": ["mountain", "desert", "caves", "newmexico"]
     },
     {

--- a/index.html
+++ b/index.html
@@ -86,6 +86,10 @@
                             <i class="fas fa-umbrella-beach"></i>
                             Beach
                         </button>
+                        <button class="filter-btn" data-filter="desert">
+                            <i class="fas fa-sun"></i>
+                            Desert
+                        </button>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Added a Desert filter button in `index.html`, matching the existing button pattern.

Fixed `type` for 3 campsites in `campsitesData.js`:
- id 32 (Arizona Desert Campground): forest → desert)
- id 33 (New Mexico High Desert Campground): mountain → desert
- id 24 (Big Bend National Park Campground): mountain → desert

Verified Desert filter shows exactly these 3-- Mountain shows 12/12 and Forest shows 4/4, and no longer include the Desert-based campsites. 