### PR TITLE
Add Desert filter button (#83)

### DIFF
--- a/campsitesData.js
+++ b/campsitesData.js
@@ -896,8 +896,8 @@ const campsitesData = [
             "Bird watching",
             "Sunset viewing"
         ],
-        "type": "forest",
-        "tags": ["forest", "desert", "hiking", "arizona"]
+        "type": "desert",
+        "tags": ["desert", "hiking", "arizona"]
     },
     {
         "id": 33,

--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
                             <i class="fas fa-tree"></i>
                             Forest
                         </button>
+                        <button class="filter-btn" data-filter="desert">
+                            <i class="fas fa-cactus"></i>
+                            Desert
+                        </button>
                         <button class="filter-btn" data-filter="beach">
                             <i class="fas fa-umbrella-beach"></i>
                             Beach

--- a/packingListData.js
+++ b/packingListData.js
@@ -133,6 +133,42 @@ const packingListsData = {
             "Camping table"
         ]
     },
+    "desert": {
+        "essentials": [
+            "Tent with good ventilation",
+            "Sleeping bags (nights get cold)",
+            "Sleeping pads",
+            "Extra water (1+ gallon per person per day)",
+            "Headlamps/flashlights",
+            "First aid kit",
+            "Electrolyte tablets",
+            "Food storage",
+            "Map and compass/GPS"
+        ],
+        "sun_and_heat": [
+            "High-SPF sunscreen",
+            "Wide-brim hat",
+            "UV sunglasses",
+            "Lightweight sun shelter / tarp",
+            "Cooling towel",
+            "Lip balm with SPF"
+        ],
+        "clothing": [
+            "Lightweight, light-colored long sleeves",
+            "Convertible pants",
+            "Sturdy closed-toe hiking shoes",
+            "Warm layer for cold nights",
+            "Buff / neck gaiter (dust & sun)",
+            "Extra socks"
+        ],
+        "comfort": [
+            "Insulated water bottle",
+            "Camp chair",
+            "Portable shade",
+            "Book or e-reader",
+            "Stargazing app (great desert night skies)"
+        ]
+    },
     "beach": {
         "essentials": [
             "Beach tent or canopy",


### PR DESCRIPTION
Fixes #83. Adds a **Desert** filter so desert campsites can be found specifically, and fixes the reported bug where "Arizona Desert Campground" appeared under **Forest**.

### Changes
- `index.html` — new Desert filter button (🌵 `fa-cactus`), following the existing button pattern.
- `campsitesData.js` — Arizona Desert Campground `type: "forest" → "desert"` (removes it from Forest, adds it to Desert); dropped its stale `"forest"` tag.
- `packingListData.js` — added a `"desert"` base packing list so the detail view is complete.

### Notes
- Scoped minimally to the ticket: only the one desert site that was mis-filed under Forest was retyped. Mountain-typed sites and the unused ES-module files were left untouched. No filter/JS logic changes.
- Verified locally: Desert filter shows only Arizona; Forest no longer shows it; All = 35; search composes; detail view shows the desert packing list.